### PR TITLE
Study nostr repo for documentation structure

### DIFF
--- a/tmp/nostr/README.CLONE_PENDING.txt
+++ b/tmp/nostr/README.CLONE_PENDING.txt
@@ -1,0 +1,3 @@
+Clone pending: https://github.com/moww20/nostr (404).
+Provide correct URL or grant access, then run:
+  git clone --depth 1 <URL> /workspace/tmp/nostr


### PR DESCRIPTION
Create a placeholder file for the `nostr` repository clone, as the original URL returned a 404.

The user requested to clone `https://github.com/moww20/nostr` into a temporary folder for documentation study. Since the repository was not found, a `README.CLONE_PENDING.txt` file was created in the intended temporary location to indicate the pending action and provide instructions for proceeding once a valid URL or access is provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb4329e9-029e-4f3a-a7a8-c7b4a611f458">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb4329e9-029e-4f3a-a7a8-c7b4a611f458">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

